### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-22.04
     steps:
       - uses: TimonVS/pr-labeler-action@v5


### PR DESCRIPTION
Potential fix for [https://github.com/frimtec/swiss-pollen/security/code-scanning/5](https://github.com/frimtec/swiss-pollen/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only has one job, you can add the `permissions` block at the job level (under `pr-labeler:`) or at the root of the workflow. The minimal required permissions for the PR labeler action are typically `contents: read` (to read repository files) and `pull-requests: write` (to add labels to PRs). You should add the following block:

```yaml
permissions:
  contents: read
  pull-requests: write
```

If you add it at the job level, it should be placed directly under `pr-labeler:` and above `runs-on:`. If you add it at the workflow level, it should be placed after the `name:` and before `on:`. Either approach is correct, but job-level is more precise if you have multiple jobs with different needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
