### PR TITLE
Bump requests from 2.32.5 to 2.33.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This module is not officially developed, supported or endorsed by [MeteoSchweiz]
 
 ## Installation
 ### Using pip
-1. Install python3.9 or higher
+1. Install python3.10 or higher
 1. Install swiss-pollen with ```pip install swiss-pollen```.
 1. Run swiss-pollen test with ```swiss-pollen```.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.32.5
+requests==2.33.0
 pytz==2026.1.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.33.0
+requests==2.33.1
 pytz==2026.1.post1


### PR DESCRIPTION
* Fixes CVE-2026-25645 caused by requests 2.32.5
* Support for python 3.9 dropped as support ended in requests 2.33.0